### PR TITLE
Hotfix: Pin GitHub Actions dependencies by SHA digest in Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,4 +11,10 @@
     addLabels: [
         'engineering-platform-team',
     ],
+    packageRules: [
+        {
+            matchManagers: ['github-actions'],
+            pinDigests: true,
+        },
+    ],
 }


### PR DESCRIPTION
Opened this based on the errors [here](https://github.com/hivemq/hivemq-swarm/actions/runs/21710276706/job/62612020863?pr=1151#step:5:185). It looks like we are one major version behind on a transitive dependency.

- Adds a `packageRules` entry to `renovate.json5` that ensures all GitHub Actions dependencies are pinned by SHA digest rather than mutable tags.
- Keeps the existing pinning convention consistent and ensures Renovate will open PRs to update Actions deps to the latest stable release with SHA-pinned references.